### PR TITLE
return to single migration with decimal type

### DIFF
--- a/src/featureflagservice/lib/featureflagservice/feature_flags/feature_flag.ex
+++ b/src/featureflagservice/lib/featureflagservice/feature_flags/feature_flag.ex
@@ -1,14 +1,13 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-
 defmodule Featureflagservice.FeatureFlags.FeatureFlag do
   use Ecto.Schema
   import Ecto.Changeset
 
   schema "featureflags" do
     field :description, :string
-    field :enabled, :float, default: 0.0
+    field :enabled, :decimal, default: 0.0
     field :name, :string
 
     timestamps()

--- a/src/featureflagservice/priv/repo/migrations/20220524172636_create_featureflags.exs
+++ b/src/featureflagservice/priv/repo/migrations/20220524172636_create_featureflags.exs
@@ -5,7 +5,7 @@ defmodule Featureflagservice.Repo.Migrations.CreateFeatureflags do
     create table(:featureflags) do
       add :name, :string
       add :description, :string
-      add :enabled, :boolean, default: false, null: false
+      add :enabled, :decimal, default: 0.0, null: false
 
       timestamps()
     end
@@ -19,25 +19,25 @@ defmodule Featureflagservice.Repo.Migrations.CreateFeatureflags do
     repo().insert(%Featureflagservice.FeatureFlags.FeatureFlag{
       name: "productCatalogFailure",
       description: "Fail product catalog service on a specific product",
-      enabled: false
+      enabled: 0.0
     })
 
     repo().insert(%Featureflagservice.FeatureFlags.FeatureFlag{
       name: "recommendationCache",
       description: "Cache recommendations",
-      enabled: false
+      enabled: 0.0
     })
 
     repo().insert(%Featureflagservice.FeatureFlags.FeatureFlag{
       name: "adServiceFailure",
       description: "Fail ad service requests sporadically",
-      enabled: false
+      enabled: 0.0
     })
 
     repo().insert(%Featureflagservice.FeatureFlags.FeatureFlag{
       name: "cartServiceFailure",
       description: "Fail cart service requests sporadically",
-      enabled: false
+      enabled: 0.0
     })
   end
 

--- a/src/featureflagservice/priv/repo/migrations/20231104172636_update_featureflags_use_float.exs
+++ b/src/featureflagservice/priv/repo/migrations/20231104172636_update_featureflags_use_float.exs
@@ -1,7 +1,0 @@
-defmodule Featureflagservice.Repo.Migrations.UpdateFeatureFlagsUseFloat do
-  use Ecto.Migration
-
-  def change do
-    "alter table featureflags alter enabled DROP DEFAULT,alter table featureflags alter enabled type numeric(2,1) using (case when enabled then 1.0 else 0.0 end), alter enabled set default '0.0';"
-  end
-end


### PR DESCRIPTION
@puckpuck I think this is more in line with what you were originally trying to do without muddying the waters with "correct" migrations.